### PR TITLE
fix(example): restore custom URL on app startup

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -127,6 +127,9 @@ class _HomePageState extends State<HomePage> {
         if (credentials['accessToken'] != null) {
           _tokenController.text = credentials['accessToken'] as String;
         }
+        if (credentials['customSyncUrl'] != null) {
+          _customUrlController.text = credentials['customSyncUrl'] as String;
+        }
       });
 
       if (hasUserId && hasAccessToken && wasSyncActive) {


### PR DESCRIPTION
## Summary
Restore custom API URL to the text field when the app restarts, matching the existing behavior for User ID and SDK Token.

## Changes
- Added restoration of `customSyncUrl` from stored credentials to `_customUrlController` in `_autoConfigureOnStartup()`

## Why
The custom URL was being stored in native Keychain and used internally by the SDK, but the UI text field was not updated on app restart. This caused confusion as users would see the default URL while their actual custom URL was being used behind the scenes.

Fixes: https://github.com/the-momentum/open_wearables_health_sdk/issues/18

## Test Plan                                                                                                       

- [ ] Enter a custom API URL and sign in
- [ ] Close and reopen the app
- [ ] Verify the custom URL is restored in the text field