### PR TITLE
fix: resolve LLDB overlapping Mach-O section warnings on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.11
+
+* Fixed LLDB "overlapping Mach-O section" warnings (`__TPRO_CONST` / `__DATA_CONST`) on iOS <17 devices when built with Xcode 15+.
+* Added `-ld_classic` linker flag in Podfile to force legacy Mach-O section layout.
+* Bumped native iOS SDK dependency from `~> 0.5.0` to `~> 0.6.0`.
+* Aligned iOS deployment target to 15.0 across all podspecs.
+
 ## 0.0.10
 
 * **Android support** — the plugin now works on both iOS and Android.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,7 +50,7 @@ android {
 
     dependencies {
         // Open Wearables Health SDK (from GitHub via JitPack)
-        implementation("com.github.the-momentum.open_wearables_android_sdk:sdk:v0.1.0")
+        implementation("com.github.the-momentum.open_wearables_android_sdk:sdk:v0.2.0")
 
         // Testing
         testImplementation("org.jetbrains.kotlin:kotlin-test")

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -30,8 +30,6 @@ flutter_ios_podfile_setup
 target 'Runner' do
   use_frameworks!
 
-  pod 'OpenWearablesHealthSDK', :git => 'https://github.com/kmlpiekarz/open_wearables_ios_sdk.git', :tag => '0.4.0'
-
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
   target 'RunnerTests' do
     inherit! :search_paths
@@ -41,5 +39,21 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+    target.build_configurations.each do |config|
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '15.0'
+      config.build_settings['BUILD_LIBRARY_FOR_DISTRIBUTION'] = 'YES'
+
+      # Xcode 26's new linker generates __TPRO_CONST segments that cause
+      # LLDB "overlapping Mach-O section" warnings on iOS <17 devices.
+      # -ld_classic reverts to the legacy linker layout. Remove once
+      # minimum deployment target is iOS 17+ or Apple resolves the LLDB
+      # incompatibility in a future Xcode release.
+      ldflags = config.build_settings['OTHER_LDFLAGS'] || ['$(inherited)']
+      ldflags = [ldflags] unless ldflags.is_a?(Array)
+      unless ldflags.any? { |f| f.include?('-ld_classic') }
+        ldflags << '-ld_classic'
+      end
+      config.build_settings['OTHER_LDFLAGS'] = ldflags
+    end
   end
 end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,16 +2,19 @@ PODS:
   - Flutter (1.0.0)
   - integration_test (0.0.1):
     - Flutter
-  - open_wearables_health_sdk (0.0.7):
+  - open_wearables_health_sdk (0.0.10):
     - Flutter
-    - OpenWearablesHealthSDK (~> 0.4.0)
-  - OpenWearablesHealthSDK (0.4.0)
+    - OpenWearablesHealthSDK (~> 0.6.0)
+  - OpenWearablesHealthSDK (0.6.0)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - open_wearables_health_sdk (from `.symlinks/plugins/open_wearables_health_sdk/ios`)
-  - OpenWearablesHealthSDK (from `https://github.com/kmlpiekarz/open_wearables_ios_sdk.git`, tag `0.4.0`)
+
+SPEC REPOS:
+  trunk:
+    - OpenWearablesHealthSDK
 
 EXTERNAL SOURCES:
   Flutter:
@@ -20,21 +23,13 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
   open_wearables_health_sdk:
     :path: ".symlinks/plugins/open_wearables_health_sdk/ios"
-  OpenWearablesHealthSDK:
-    :git: https://github.com/kmlpiekarz/open_wearables_ios_sdk.git
-    :tag: 0.4.0
-
-CHECKOUT OPTIONS:
-  OpenWearablesHealthSDK:
-    :git: https://github.com/kmlpiekarz/open_wearables_ios_sdk.git
-    :tag: 0.4.0
 
 SPEC CHECKSUMS:
-  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
-  open_wearables_health_sdk: 4a0219a44cc911db70b87f6de9b92c88ccd2479a
-  OpenWearablesHealthSDK: 0ed17b6c14979feb989c82e7131271bd366cd14a
+  open_wearables_health_sdk: 03e7de6ccf98a19bee3d3b166d70ce079170bfc1
+  OpenWearablesHealthSDK: adf0f864cba78d8a2095384dfefb84abc100646a
 
-PODFILE CHECKSUM: 4a62d31892649c3576592f73a131f3d58f64cfa6
+PODFILE CHECKSUM: 60cab67f4dc96bdfae4c256ac14905e1caa2afc3
 
 COCOAPODS: 1.16.2

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -476,7 +476,7 @@
 				DEVELOPMENT_TEAM = 33PBA72JFF;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -661,7 +661,7 @@
 				DEVELOPMENT_TEAM = 33PBA72JFF;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -686,7 +686,7 @@
 				DEVELOPMENT_TEAM = 33PBA72JFF;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -176,7 +176,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.7"
+    version: "0.0.10"
   path:
     dependency: transitive
     description:

--- a/ios/open_wearables_health_sdk.podspec
+++ b/ios/open_wearables_health_sdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'open_wearables_health_sdk'
-  s.version          = '0.0.7'
+  s.version          = '0.0.11'
   s.summary          = 'Flutter SDK for background health data synchronization to Open Wearables platform.'
   s.description      = <<-DESC
 Flutter SDK for secure background health data synchronization from Apple HealthKit to the Open Wearables platform.
@@ -14,14 +14,15 @@ Uses the native OpenWearablesHealthSDK under the hood.
   s.source_files = 'Classes/**/*.{h,m,swift}'
 
   s.dependency 'Flutter'
-  s.dependency 'OpenWearablesHealthSDK', '~> 0.4.0'
+  s.dependency 'OpenWearablesHealthSDK', '~> 0.6.0'
 
-  s.platform = :ios, '14.0'
+  s.platform = :ios, '15.0'
   s.swift_version = '5.0'
 
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
-    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386'
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386',
+    'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES'
   }
 
   s.frameworks = 'HealthKit', 'BackgroundTasks', 'UIKit'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: open_wearables_health_sdk
 description: "Flutter SDK for secure background health data synchronization from Apple HealthKit (iOS) and Samsung Health / Health Connect (Android) to the Open Wearables platform."
-version: 0.0.10
+version: 0.0.11
 homepage: https://openwearables.io
 repository: https://github.com/the-momentum/open_wearables_health_sdk
 issue_tracker: https://github.com/the-momentum/open_wearables_health_sdk/issues


### PR DESCRIPTION
## Summary
- Fixes LLDB `overlapping Mach-O section` warnings (`__TPRO_CONST` / `__DATA_CONST`) reported on physical iOS <17 devices when building with Xcode 15+.
- Forces legacy linker (`-ld_classic`) in Podfile `post_install` to avoid generating segments unsupported by older dyld.
- Bumps native iOS SDK dependency to `~> 0.6.0`, aligns deployment target to iOS 15.0.
