### PR TITLE
fix: change foreground service type from dataSync to health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.17
+
+* **Breaking: Foreground service type changed from `dataSync` to `health`** to comply with Google Play policy. Apps must update their Play Console FGS declaration from "Data Sync" to "Health" and remove any manual `<service android:foregroundServiceType="dataSync">` from their `AndroidManifest.xml` — the SDK now provides the correct declaration via manifest merge.
+* Added `FOREGROUND_SERVICE_HEALTH` and `HIGH_SAMPLING_RATE_SENSORS` permissions to the plugin manifest.
+* Updated README with Android foreground service requirements, Play Console declaration guide, and mandatory `setSyncNotification()` usage.
+* Bumped native Android SDK dependency from `v0.7.0` to `v0.8.0`.
+
 ## 0.0.16
 
 * Bumped native iOS SDK dependency from `~> 0.9.0` to `~> 0.10.0`.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,55 @@ class MainActivity : FlutterFragmentActivity()
 
 This is required for Health Connect permission dialogs to work.
 
+#### Background Sync & Foreground Service (required for Play Store)
+
+The SDK uses a WorkManager foreground service to sync health data in the background. Starting with Android 14, Google Play requires a correct **foreground service type** declaration. Since this SDK accesses health data, the correct type is `health` (not `dataSync`).
+
+The SDK's `AndroidManifest.xml` already declares the correct service, permissions, and FGS type — they are automatically merged into your app via manifest merging. **You do not need to add a service declaration yourself.**
+
+The following are added automatically by the SDK:
+
+```xml
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE_HEALTH" />
+<uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS" />
+
+<service
+    android:name="androidx.work.impl.foreground.SystemForegroundService"
+    android:foregroundServiceType="health"
+    tools:node="merge" />
+```
+
+> **Warning:** If you previously declared the service manually with `foregroundServiceType="dataSync"`, **remove it** from your `AndroidManifest.xml`. Using `dataSync` for health data will cause Google Play rejection.
+
+##### Play Console declaration
+
+When submitting to Google Play, you must declare the foreground service type in the Play Console:
+
+1. Go to **Policy > App content > Foreground service permissions**
+2. Select **Health** as your foreground service type
+3. Describe the use case: *"The app reads health data from Health Connect (steps, heart rate, sleep, etc.) and synchronizes it in the background to the user's account."*
+4. Explain what happens if interrupted: *"If the sync is interrupted, it automatically resumes on next app launch or when the system allows. No data is lost."*
+5. Provide a video or screenshots showing:
+   - The user granting Health Connect permissions
+   - A visible notification during background sync (see `setSyncNotification` below)
+   - The in-app UI indicating that sync is active
+
+##### Foreground notification (required)
+
+Android requires a visible notification while a foreground service is running. Call `setSyncNotification` **before** starting background sync so the user can see what's happening:
+
+```dart
+if (Platform.isAndroid) {
+  await OpenWearablesHealthSdk.setSyncNotification(
+    title: 'MyApp',
+    text: 'Syncing your health data...',
+  );
+}
+```
+
+This notification is a Play Store requirement — without it, your app will be rejected for "FGS not perceptible to the user".
+
 #### Samsung Health
 
 Samsung Health is supported out of the box - the Samsung Health Data SDK is bundled in the Android SDK repository. No extra download needed.
@@ -263,6 +312,15 @@ class HealthService {
     await OpenWearablesHealthSdk.requestAuthorization(
       types: HealthDataType.values,
     );
+
+    // Required on Android: set a visible notification before starting sync
+    if (Platform.isAndroid) {
+      await OpenWearablesHealthSdk.setSyncNotification(
+        title: 'Health sync active',
+        text: 'Syncing your health data...',
+      );
+    }
+
     await OpenWearablesHealthSdk.startBackgroundSync();
   }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,7 +50,7 @@ android {
 
     dependencies {
         // Open Wearables Health SDK (from GitHub via JitPack)
-        implementation("com.github.the-momentum.open_wearables_android_sdk:sdk:v0.7.0")
+        implementation("com.github.the-momentum.open_wearables_android_sdk:sdk:v0.8.0")
 
         // Testing
         testImplementation("org.jetbrains.kotlin:kotlin-test")

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,15 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.openwearables.health.sdk.flutter">
+
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_HEALTH" />
+    <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS" />
+
+    <application>
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="health"
+            tools:node="merge" />
+    </application>
 </manifest>

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -48,12 +48,6 @@
             </intent-filter>
         </activity-alias>
 
-        <!-- WorkManager foreground service for background health sync -->
-        <service
-            android:name="androidx.work.impl.foreground.SystemForegroundService"
-            android:foregroundServiceType="dataSync"
-            tools:node="merge" />
-
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -176,7 +176,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.16"
+    version: "0.0.17"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: open_wearables_health_sdk
 description: "Flutter SDK for secure background health data synchronization from Apple HealthKit (iOS) and Samsung Health / Health Connect (Android) to the Open Wearables platform."
-version: 0.0.16
+version: 0.0.17
 homepage: https://openwearables.io
 repository: https://github.com/the-momentum/open_wearables_health_sdk
 issue_tracker: https://github.com/the-momentum/open_wearables_health_sdk/issues


### PR DESCRIPTION
## Summary

- Bumped native Android SDK dependency from `v0.7.0` to `v0.8.0`
- Changed `foregroundServiceType` from `dataSync` to `health` in the Flutter plugin manifest
- Added `FOREGROUND_SERVICE_HEALTH` and `HIGH_SAMPLING_RATE_SENSORS` permissions to the
  plugin manifest (auto-merged into consumer apps)
- Removed manual `<service>` declaration from example app - the SDK and native dependency
  now provide it via manifest merge
- Updated README with new section on Android foreground service requirements: Play Console
  declaration, mandatory `setSyncNotification()` usage, and review guidelines
- Bumped plugin version to `0.0.17`
