### PR TITLE
Bump native SDKs (iOS 0.13.0, Android 0.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.0.20
+
+* Bumped native iOS SDK dependency from `~> 0.12.0` to `~> 0.13.0`.
+* Bumped native Android SDK dependency from `v0.9.0` to `v0.10.0`.
+* **Sync telemetry**: both iOS and Android SDKs now send diagnostic events (`sync_start`, per-type `sync_end`, `device_state`) to the `/logs` endpoint during initial full syncs.
+* **Android: auto full export**: first sync now automatically runs as full export, matching iOS behavior.
+* **Android: fixed OkHttp connection leaks** in sync uploads and log requests.
+
 ## 0.0.19
 
 * Bumped native iOS SDK dependency from `~> 0.11.0` to `~> 0.12.0`.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,8 +49,7 @@ android {
     }
 
     dependencies {
-        // Open Wearables Health SDK (from GitHub via JitPack)
-        implementation("com.github.the-momentum.open_wearables_android_sdk:sdk:v0.9.0")
+        implementation("com.github.the-momentum.open_wearables_android_sdk:sdk:v0.10.0")
 
         // Testing
         testImplementation("org.jetbrains.kotlin:kotlin-test")

--- a/example/android/settings.gradle.kts
+++ b/example/android/settings.gradle.kts
@@ -20,6 +20,7 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.9.1" apply false
+    id("com.android.library") version "8.9.1" apply false
     id("org.jetbrains.kotlin.android") version "2.1.0" apply false
 }
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,10 +2,10 @@ PODS:
   - Flutter (1.0.0)
   - integration_test (0.0.1):
     - Flutter
-  - open_wearables_health_sdk (0.0.18):
+  - open_wearables_health_sdk (0.0.20):
     - Flutter
-    - OpenWearablesHealthSDK (~> 0.11.0)
-  - OpenWearablesHealthSDK (0.11.0)
+    - OpenWearablesHealthSDK (~> 0.13.0)
+  - OpenWearablesHealthSDK (0.13.0)
   - package_info_plus (0.4.5):
     - Flutter
   - Sentry/HybridSDK (8.58.0)
@@ -41,8 +41,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
-  open_wearables_health_sdk: d384f7081cb94f863eef66350922e315bc52e064
-  OpenWearablesHealthSDK: d7f5957c2de56c614c9c66295f10bd9e6e2d7488
+  open_wearables_health_sdk: 42b6c8d7053da5c053f1a41430471bc37ccf40ef
+  OpenWearablesHealthSDK: 95bfb91cb2236faf7a0359f5017299cbae47889a
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   Sentry: d587a8fe91ca13503ecd69a1905f3e8a0fcf61be
   sentry_flutter: 31101687061fb85211ebab09ce6eb8db4e9ba74f

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -221,7 +221,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.19"
+    version: "0.0.20"
   package_config:
     dependency: transitive
     description:

--- a/ios/open_wearables_health_sdk.podspec
+++ b/ios/open_wearables_health_sdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'open_wearables_health_sdk'
-  s.version          = '0.0.19'
+  s.version          = '0.0.20'
   s.summary          = 'Flutter SDK for background health data synchronization to Open Wearables platform.'
   s.description      = <<-DESC
 Flutter SDK for secure background health data synchronization from Apple HealthKit to the Open Wearables platform.
@@ -14,7 +14,7 @@ Uses the native OpenWearablesHealthSDK under the hood.
   s.source_files = 'Classes/**/*.{h,m,swift}'
 
   s.dependency 'Flutter'
-  s.dependency 'OpenWearablesHealthSDK', '~> 0.12.0'
+  s.dependency 'OpenWearablesHealthSDK', '~> 0.13.0'
 
   s.platform = :ios, '15.0'
   s.swift_version = '5.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: open_wearables_health_sdk
 description: "Flutter SDK for secure background health data synchronization from Apple HealthKit (iOS) and Samsung Health / Health Connect (Android) to the Open Wearables platform."
-version: 0.0.19
+version: 0.0.20
 homepage: https://openwearables.io
 repository: https://github.com/the-momentum/open_wearables_health_sdk
 issue_tracker: https://github.com/the-momentum/open_wearables_health_sdk/issues


### PR DESCRIPTION
## Summary
- iOS SDK ~> 0.13.0, Android SDK v0.10.0 — sync telemetry support
- Reverted temporary local SDK overrides in example app