### PR TITLE
feat: extend HealthDataType with 8 additional dietary nutrients

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -32,6 +32,15 @@ target 'Runner' do
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
+  # Override the CocoaPods-published OpenWearablesHealthSDK 0.13.0 binary
+  # with srirsiva's fork on the dietary-types branch. The published 0.13.0
+  # release predates the streaming sync-state writes we depend on for the
+  # live progress card, AND we need the Swift-side dietary type extension
+  # to actually compile in (CocoaPods binary is stock upstream).
+  pod 'OpenWearablesHealthSDK',
+      :git => 'https://github.com/srirsiva/open_wearables_ios_sdk.git',
+      :branch => 'feat/extended-dietary-types'
+
   target 'RunnerTests' do
     inherit! :search_paths
   end

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -279,9 +279,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -473,7 +477,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = 33PBA72JFF;
+				DEVELOPMENT_TEAM = A7LTPZGA67;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -481,7 +485,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.momentum.health.export.healthBgSyncExample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sriramsivakumar.openwearables.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -498,7 +502,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.momentum.health.export.healthBgSyncExample.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sriramsivakumar.openwearables.example.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -516,7 +520,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.momentum.health.export.healthBgSyncExample.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sriramsivakumar.openwearables.example.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -532,7 +536,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.momentum.health.export.healthBgSyncExample.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sriramsivakumar.openwearables.example.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -658,7 +662,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = 33PBA72JFF;
+				DEVELOPMENT_TEAM = A7LTPZGA67;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -666,7 +670,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.momentum.health.export.healthBgSyncExample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sriramsivakumar.openwearables.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -683,7 +687,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = 33PBA72JFF;
+				DEVELOPMENT_TEAM = A7LTPZGA67;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -691,7 +695,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.momentum.health.export.healthBgSyncExample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sriramsivakumar.openwearables.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -12,7 +12,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Open Wearables</string>
+	<string>Vytls</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -20,7 +20,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>Open Wearables</string>
+	<string>Vytls</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -78,7 +78,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Open Wearables',
+      title: 'Vytls',
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
         brightness: Brightness.dark,
@@ -298,7 +298,7 @@ class _HomePageState extends State<HomePage> {
       if (Platform.isAndroid) {
         await _loadAvailableProviders();
         await OpenWearablesHealthSdk.setSyncNotification(
-          title: '🏃 Open Wearables',
+          title: '🏃 Vytls',
           text: '⚡ Sync in progress — keeping your health data fresh 💪',
         );
       }
@@ -564,7 +564,7 @@ class _HomePageState extends State<HomePage> {
             backgroundColor: OWColors.background,
             flexibleSpace: FlexibleSpaceBar(
               title: const Text(
-                'Open Wearables',
+                'Vytls',
                 style: TextStyle(color: OWColors.textPrimary, fontSize: 20, fontWeight: FontWeight.w600),
               ),
               titlePadding: const EdgeInsets.only(left: 20, bottom: 16),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -7,6 +8,7 @@ import 'package:http/http.dart' as http;
 import 'package:open_wearables_health_sdk/health_data_type.dart';
 import 'package:open_wearables_health_sdk/open_wearables_health_sdk.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 
 // Open Wearables design tokens
 class OWColors {
@@ -127,6 +129,15 @@ class _HomePageState extends State<HomePage> {
   final _customDaysController = TextEditingController();
   bool _isCustomDays = false;
 
+  // ── Sync progress tracking ────────────────────────────────────────
+  // Polled from native via getSyncStatus() every 2s while syncing so the
+  // user gets a live progress card with completed types / records sent /
+  // elapsed / ETA. Keeps the screen awake (configurable) while running.
+  Timer? _progressTimer;
+  Map<String, dynamic>? _syncStatus;
+  DateTime? _syncStartedAt;
+  bool _keepScreenAwake = true;
+
   // Provider selection (Android only)
   List<AvailableProvider> _availableProviders = [];
   String? _selectedProviderId;
@@ -194,6 +205,7 @@ class _HomePageState extends State<HomePage> {
         _isSyncing = false;
         _statusMessage = 'Session expired - please sign in again';
       });
+      _stopProgressTracking();
     }
   }
 
@@ -202,7 +214,55 @@ class _HomePageState extends State<HomePage> {
     _hostController.dispose();
     _invitationCodeController.dispose();
     _customDaysController.dispose();
+    _progressTimer?.cancel();
+    WakelockPlus.disable();
     super.dispose();
+  }
+
+  // ── Progress polling ──────────────────────────────────────────────
+
+  void _startProgressTracking() {
+    _syncStartedAt = DateTime.now();
+    _progressTimer?.cancel();
+    _pollSyncStatus(); // immediate first poll
+    _progressTimer = Timer.periodic(const Duration(seconds: 2), (_) => _pollSyncStatus());
+    if (_keepScreenAwake) {
+      WakelockPlus.enable();
+    }
+  }
+
+  void _stopProgressTracking() {
+    _progressTimer?.cancel();
+    _progressTimer = null;
+    WakelockPlus.disable();
+    if (mounted) {
+      setState(() {
+        _syncStatus = null;
+        _syncStartedAt = null;
+      });
+    }
+  }
+
+  Future<void> _pollSyncStatus() async {
+    try {
+      final status = await OpenWearablesHealthSdk.getSyncStatus();
+      final stillActive = OpenWearablesHealthSdk.isSyncActive;
+      if (!mounted) return;
+      setState(() {
+        _syncStatus = status;
+        if (!stillActive && _isSyncing) {
+          _isSyncing = false;
+        }
+      });
+      if (!stillActive) {
+        // Sync just finished — keep status visible briefly, then clean up.
+        _progressTimer?.cancel();
+        _progressTimer = null;
+        WakelockPlus.disable();
+      }
+    } catch (_) {
+      // Swallow errors — keep last known status visible.
+    }
   }
 
   Future<void> _autoConfigureOnStartup() async {
@@ -373,11 +433,17 @@ class _HomePageState extends State<HomePage> {
   }
 
   void _checkStatus() {
+    final wasSyncing = _isSyncing;
     setState(() {
       _isSignedIn = OpenWearablesHealthSdk.isSignedIn;
       _isSyncing = OpenWearablesHealthSdk.isSyncActive;
       if (_isSyncing) _isAuthorized = true;
     });
+    // If we just discovered a sync is in flight (e.g. app reopened mid-sync),
+    // start the progress tracker so the UI catches up.
+    if (_isSyncing && !wasSyncing && _progressTimer == null) {
+      _startProgressTracking();
+    }
   }
 
   void _setStatus(String message) {
@@ -434,6 +500,9 @@ class _HomePageState extends State<HomePage> {
       final label = _syncDaysBack != null ? 'last $_syncDaysBack days' : 'full history';
       final started = await OpenWearablesHealthSdk.startBackgroundSync(syncDaysBack: _syncDaysBack);
       setState(() => _isSyncing = started);
+      if (started) {
+        _startProgressTracking();
+      }
       _setStatus(started ? 'Sync started ($label)' : 'Could not start sync');
       if (!started) {
         Sentry.captureEvent(
@@ -459,6 +528,7 @@ class _HomePageState extends State<HomePage> {
     try {
       await OpenWearablesHealthSdk.stopBackgroundSync();
       setState(() => _isSyncing = false);
+      _stopProgressTracking();
       _setStatus('Sync stopped');
     } catch (e, stackTrace) {
       _setStatus('Error: $e');
@@ -515,6 +585,11 @@ class _HomePageState extends State<HomePage> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   _buildStatusCard(),
+                  // Live progress card — only renders while syncing.
+                  if (_isSyncing) ...[
+                    const SizedBox(height: 16),
+                    _buildProgressCard(),
+                  ],
                   const SizedBox(height: 24),
 
                   if (!_isSignedIn) ...[
@@ -603,6 +678,155 @@ class _HomePageState extends State<HomePage> {
         ],
       ),
     );
+  }
+
+  // ── Progress card ─────────────────────────────────────────────────
+  // Live progress while a backfill is running. Driven by getSyncStatus()
+  // polled every 2s. Shows: types completed bar (denominator =
+  // HealthDataType.values.length), records sent counter, elapsed timer,
+  // rough ETA, and a wakelock toggle.
+  Widget _buildProgressCard() {
+    final s = _syncStatus ?? const <String, dynamic>{};
+    final completedTypes = (s['completedTypes'] as int?) ?? 0;
+    final sentCount = (s['sentCount'] as int?) ?? 0;
+    final totalTypes = HealthDataType.values.length;
+    final progress = totalTypes > 0 ? (completedTypes / totalTypes).clamp(0.0, 1.0) : 0.0;
+    final percent = (progress * 100).toInt();
+
+    String? elapsedStr;
+    String? etaStr;
+    if (_syncStartedAt != null) {
+      final elapsed = DateTime.now().difference(_syncStartedAt!);
+      if (elapsed.inHours > 0) {
+        elapsedStr = '${elapsed.inHours}h ${elapsed.inMinutes % 60}m';
+      } else if (elapsed.inMinutes > 0) {
+        elapsedStr = '${elapsed.inMinutes}m ${elapsed.inSeconds % 60}s';
+      } else {
+        elapsedStr = '${elapsed.inSeconds}s';
+      }
+      if (elapsed.inSeconds > 5 && completedTypes > 0 && completedTypes < totalTypes) {
+        final ratePerSec = completedTypes / elapsed.inSeconds;
+        if (ratePerSec > 0) {
+          final remainSec = (totalTypes - completedTypes) / ratePerSec;
+          if (remainSec < 60) {
+            etaStr = '~${remainSec.toInt()}s left';
+          } else if (remainSec < 3600) {
+            etaStr = '~${(remainSec / 60).toInt()} min left';
+          } else {
+            etaStr = '~${(remainSec / 3600).toStringAsFixed(1)}h left';
+          }
+        }
+      }
+    }
+
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: OWColors.surface.withValues(alpha: 0.7),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: OWColors.success.withValues(alpha: 0.3)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(CupertinoIcons.arrow_down_circle_fill, color: OWColors.success, size: 22),
+              const SizedBox(width: 10),
+              const Text(
+                'Sync progress',
+                style: TextStyle(
+                  fontSize: 17,
+                  fontWeight: FontWeight.w600,
+                  letterSpacing: -0.3,
+                  color: OWColors.textPrimary,
+                ),
+              ),
+              const Spacer(),
+              Text(
+                '$percent%',
+                style: const TextStyle(
+                  fontSize: 17,
+                  fontWeight: FontWeight.w600,
+                  color: OWColors.success,
+                  fontFeatures: [FontFeature.tabularFigures()],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 14),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: LinearProgressIndicator(
+              value: progress,
+              minHeight: 8,
+              backgroundColor: OWColors.surfaceLight,
+              valueColor: const AlwaysStoppedAnimation(OWColors.success),
+            ),
+          ),
+          const SizedBox(height: 14),
+          _statRow('Types complete', '$completedTypes / $totalTypes'),
+          _statRow('Records sent', _formatCount(sentCount)),
+          if (elapsedStr != null) _statRow('Elapsed', elapsedStr),
+          if (etaStr != null) _statRow('Remaining', etaStr),
+          const SizedBox(height: 12),
+          const Divider(height: 1, color: OWColors.borderSubtle),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              CupertinoSwitch(
+                value: _keepScreenAwake,
+                activeTrackColor: OWColors.success,
+                onChanged: (v) {
+                  setState(() => _keepScreenAwake = v);
+                  if (_isSyncing) {
+                    if (v) {
+                      WakelockPlus.enable();
+                    } else {
+                      WakelockPlus.disable();
+                    }
+                  }
+                },
+              ),
+              const SizedBox(width: 12),
+              const Expanded(
+                child: Text(
+                  'Keep screen awake while syncing',
+                  style: TextStyle(fontSize: 14, color: OWColors.textSecondary),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _statRow(String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 3),
+      child: Row(
+        children: [
+          Text(label, style: const TextStyle(fontSize: 14, color: OWColors.textSecondary)),
+          const Spacer(),
+          Text(
+            value,
+            style: const TextStyle(
+              fontSize: 14,
+              color: OWColors.textPrimary,
+              fontWeight: FontWeight.w500,
+              fontFeatures: [FontFeature.tabularFigures()],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatCount(int n) {
+    if (n < 1000) return '$n';
+    if (n < 1000000) return '${(n / 1000).toStringAsFixed(1)}K';
+    return '${(n / 1000000).toStringAsFixed(2)}M';
   }
 
   Widget _buildLoginSection() {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -130,12 +130,24 @@ class _HomePageState extends State<HomePage> {
   bool _isCustomDays = false;
 
   // ── Sync progress tracking ────────────────────────────────────────
-  // Polled from native via getSyncStatus() every 2s while syncing so the
-  // user gets a live progress card with completed types / records sent /
-  // elapsed / ETA. Keeps the screen awake (configurable) while running.
-  Timer? _progressTimer;
-  Map<String, dynamic>? _syncStatus;
+  // Driven by parsing the native logStream (more robust than polling
+  // getSyncStatus, because the SDK clears the state file on completion +
+  // userKey mismatches can return nil mid-sync). The log lines we care
+  // about all flow through MethodChannelOpenWearablesHealthSdk.logStream
+  // and are already subscribed in _subscribeToNativeLogs.
+  //
+  // Parsed signals:
+  //   "Types to sync (N):"           → _totalTypes = N
+  //   "<TypeName>: complete (anchor"  → _completedTypes += 1
+  //   "Sending X KB, Y items"         → _recordsSent += Y
+  //   "Sync complete: X samples ..."  → final freeze
+  //   "Sync started"                  → reset counters, start timer
+  Timer? _progressTimer;          // only used to nudge UI repaints for ETA
   DateTime? _syncStartedAt;
+  int _totalTypes = 0;            // 0 until first log line tells us
+  int _completedTypes = 0;
+  int _recordsSent = 0;
+  bool _syncFinishedFlash = false; // true briefly after final "Sync complete"
   bool _keepScreenAwake = true;
 
   // Provider selection (Android only)
@@ -153,6 +165,9 @@ class _HomePageState extends State<HomePage> {
     MethodChannelOpenWearablesHealthSdk.logStream.listen((message) {
       final timestamp = DateTime.now().toIso8601String().split('T').last.split('.').first;
       _addLog('$timestamp $message');
+
+      // Parse progress signals from the native log stream.
+      _parseProgressFromLog(message);
 
       Sentry.addBreadcrumb(Breadcrumb(category: 'sdk.log', message: message, level: _sentryLevelFromLog(message)));
     });
@@ -219,49 +234,110 @@ class _HomePageState extends State<HomePage> {
     super.dispose();
   }
 
-  // ── Progress polling ──────────────────────────────────────────────
+  // ── Progress tracking (log-parser driven) ───────────────────────
 
   void _startProgressTracking() {
-    _syncStartedAt = DateTime.now();
+    setState(() {
+      _syncStartedAt = DateTime.now();
+      _totalTypes = 0;
+      _completedTypes = 0;
+      _recordsSent = 0;
+      _syncFinishedFlash = false;
+    });
     _progressTimer?.cancel();
-    _pollSyncStatus(); // immediate first poll
-    _progressTimer = Timer.periodic(const Duration(seconds: 2), (_) => _pollSyncStatus());
+    // Tick once a second purely so the elapsed/ETA strings refresh in UI.
+    _progressTimer = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (mounted) setState(() {});
+    });
     if (_keepScreenAwake) {
       WakelockPlus.enable();
     }
   }
 
-  void _stopProgressTracking() {
+  void _stopProgressTracking({bool keepFinalSnapshot = false}) {
     _progressTimer?.cancel();
     _progressTimer = null;
     WakelockPlus.disable();
-    if (mounted) {
+    if (mounted && !keepFinalSnapshot) {
       setState(() {
-        _syncStatus = null;
         _syncStartedAt = null;
+        _totalTypes = 0;
+        _completedTypes = 0;
+        _recordsSent = 0;
+        _syncFinishedFlash = false;
       });
     }
   }
 
-  Future<void> _pollSyncStatus() async {
-    try {
-      final status = await OpenWearablesHealthSdk.getSyncStatus();
-      final stillActive = OpenWearablesHealthSdk.isSyncActive;
-      if (!mounted) return;
-      setState(() {
-        _syncStatus = status;
-        if (!stillActive && _isSyncing) {
-          _isSyncing = false;
-        }
-      });
-      if (!stillActive) {
-        // Sync just finished — keep status visible briefly, then clean up.
-        _progressTimer?.cancel();
-        _progressTimer = null;
-        WakelockPlus.disable();
+  /// Parses one native log line for progress signals. Cheap regex matches —
+  /// runs on every log message so kept very tight.
+  void _parseProgressFromLog(String message) {
+    if (!_isSyncing && !_syncFinishedFlash) return;
+
+    // "Types to sync (N): TypeA, TypeB, ..."
+    final typesMatch = RegExp(r'Types to sync \((\d+)\)').firstMatch(message);
+    if (typesMatch != null) {
+      final n = int.tryParse(typesMatch.group(1) ?? '');
+      if (n != null && mounted) {
+        setState(() => _totalTypes = n);
       }
-    } catch (_) {
-      // Swallow errors — keep last known status visible.
+      return;
+    }
+
+    // "<TypeName>: complete (anchor captured)" — one type fully done.
+    if (message.contains('complete (anchor captured)')) {
+      if (mounted) {
+        setState(() => _completedTypes += 1);
+      }
+      return;
+    }
+
+    // "Sending X KB, Y items (...)" — chunk being POSTed.
+    final sendMatch = RegExp(r'Sending [\d.]+ KB, (\d+) items').firstMatch(message);
+    if (sendMatch != null) {
+      final n = int.tryParse(sendMatch.group(1) ?? '');
+      if (n != null && mounted) {
+        setState(() => _recordsSent += n);
+      }
+      return;
+    }
+
+    // "Sync complete: X samples across Y types" — final summary; freeze values.
+    final completeMatch = RegExp(r'Sync complete: (\d+) samples across (\d+) types').firstMatch(message);
+    if (completeMatch != null) {
+      final samples = int.tryParse(completeMatch.group(1) ?? '');
+      final types = int.tryParse(completeMatch.group(2) ?? '');
+      if (mounted) {
+        setState(() {
+          if (samples != null) _recordsSent = samples;
+          if (types != null) _completedTypes = types;
+          _syncFinishedFlash = true;
+        });
+        // Hold final snapshot visible for 30s, then auto-collapse.
+        Future.delayed(const Duration(seconds: 30), () {
+          if (mounted) {
+            setState(() => _syncFinishedFlash = false);
+            _stopProgressTracking();
+          }
+        });
+      }
+      return;
+    }
+
+    // "Sync started" — a new sync session began (e.g., observer-driven incremental).
+    if (message.contains('Sync started') && !_isSyncing) {
+      // SDK started a sync without explicit user action (background observer).
+      // Treat as new session — reset counters but keep tracking enabled.
+      if (mounted) {
+        setState(() {
+          _isSyncing = true;
+          _syncStartedAt = DateTime.now();
+          _totalTypes = 0;
+          _completedTypes = 0;
+          _recordsSent = 0;
+          _syncFinishedFlash = false;
+        });
+      }
     }
   }
 
@@ -585,8 +661,9 @@ class _HomePageState extends State<HomePage> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   _buildStatusCard(),
-                  // Live progress card — only renders while syncing.
-                  if (_isSyncing) ...[
+                  // Live progress card — renders while syncing AND for ~30s
+                  // after completion so the user sees the final tally.
+                  if (_isSyncing || _syncFinishedFlash) ...[
                     const SizedBox(height: 16),
                     _buildProgressCard(),
                   ],
@@ -681,16 +758,18 @@ class _HomePageState extends State<HomePage> {
   }
 
   // ── Progress card ─────────────────────────────────────────────────
-  // Live progress while a backfill is running. Driven by getSyncStatus()
-  // polled every 2s. Shows: types completed bar (denominator =
-  // HealthDataType.values.length), records sent counter, elapsed timer,
-  // rough ETA, and a wakelock toggle.
+  // Live progress driven by parsing the native log stream. Robust to the
+  // SDK clearing its state file mid-flight + handles the streaming sync's
+  // multiple session boundaries (start → complete → re-start observer).
+  // Shows: completed-types bar, records-sent counter, elapsed timer,
+  // rough ETA, wakelock toggle.
   Widget _buildProgressCard() {
-    final s = _syncStatus ?? const <String, dynamic>{};
-    final completedTypes = (s['completedTypes'] as int?) ?? 0;
-    final sentCount = (s['sentCount'] as int?) ?? 0;
-    final totalTypes = HealthDataType.values.length;
-    final progress = totalTypes > 0 ? (completedTypes / totalTypes).clamp(0.0, 1.0) : 0.0;
+    final completedTypes = _completedTypes;
+    final sentCount = _recordsSent;
+    final totalTypes = _totalTypes > 0 ? _totalTypes : HealthDataType.values.length;
+    final progress = _syncFinishedFlash
+        ? 1.0
+        : (totalTypes > 0 ? (completedTypes / totalTypes).clamp(0.0, 1.0) : 0.0);
     final percent = (progress * 100).toInt();
 
     String? elapsedStr;
@@ -731,11 +810,15 @@ class _HomePageState extends State<HomePage> {
         children: [
           Row(
             children: [
-              const Icon(CupertinoIcons.arrow_down_circle_fill, color: OWColors.success, size: 22),
+              Icon(
+                _syncFinishedFlash ? CupertinoIcons.checkmark_circle_fill : CupertinoIcons.arrow_down_circle_fill,
+                color: OWColors.success,
+                size: 22,
+              ),
               const SizedBox(width: 10),
-              const Text(
-                'Sync progress',
-                style: TextStyle(
+              Text(
+                _syncFinishedFlash ? 'Sync complete' : 'Sync progress',
+                style: const TextStyle(
                   fontSize: 17,
                   fontWeight: FontWeight.w600,
                   letterSpacing: -0.3,
@@ -744,7 +827,7 @@ class _HomePageState extends State<HomePage> {
               ),
               const Spacer(),
               Text(
-                '$percent%',
+                _syncFinishedFlash ? '✓' : '$percent%',
                 style: const TextStyle(
                   fontSize: 17,
                   fontWeight: FontWeight.w600,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -308,6 +308,12 @@ class _HomePageState extends State<HomePage> {
       final samples = int.tryParse(completeMatch.group(1) ?? '');
       final types = int.tryParse(completeMatch.group(2) ?? '');
       if (mounted) {
+        // Stop the 1s UI tick immediately so elapsed timer freezes at the
+        // value it had at completion. Without this it would keep ticking
+        // forever (or for 30s) past the actual sync end.
+        _progressTimer?.cancel();
+        _progressTimer = null;
+        WakelockPlus.disable();
         setState(() {
           if (samples != null) _recordsSent = samples;
           if (types != null) _completedTypes = types;

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -29,6 +29,9 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   http: ^1.6.0
+  # Keep iOS auto-lock disabled while a backfill is running so the user
+  # can leave the app foregrounded without the screen turning off.
+  wakelock_plus: ^1.2.10
 
 dev_dependencies:
   integration_test:

--- a/lib/health_data_type.dart
+++ b/lib/health_data_type.dart
@@ -40,11 +40,19 @@ enum HealthDataType {
   bloodPressureSystolic,
   bloodPressureDiastolic,
   bloodPressure, // correlation
-  // Nutrition (examples)
+  // Nutrition
   dietaryEnergyConsumed,
   dietaryCarbohydrates,
   dietaryProtein,
   dietaryFatTotal,
+  dietaryFatSaturated,
+  dietaryFatMonounsaturated,
+  dietaryFatPolyunsaturated,
+  dietaryFiber,
+  dietarySugar,
+  dietarySodium,
+  dietaryCholesterol,
+  dietaryCaffeine,
   dietaryWater,
 
   // Sleep / mindfulness
@@ -145,6 +153,22 @@ extension HealthDataTypeId on HealthDataType {
         return 'dietaryProtein';
       case HealthDataType.dietaryFatTotal:
         return 'dietaryFatTotal';
+      case HealthDataType.dietaryFatSaturated:
+        return 'dietaryFatSaturated';
+      case HealthDataType.dietaryFatMonounsaturated:
+        return 'dietaryFatMonounsaturated';
+      case HealthDataType.dietaryFatPolyunsaturated:
+        return 'dietaryFatPolyunsaturated';
+      case HealthDataType.dietaryFiber:
+        return 'dietaryFiber';
+      case HealthDataType.dietarySugar:
+        return 'dietarySugar';
+      case HealthDataType.dietarySodium:
+        return 'dietarySodium';
+      case HealthDataType.dietaryCholesterol:
+        return 'dietaryCholesterol';
+      case HealthDataType.dietaryCaffeine:
+        return 'dietaryCaffeine';
       case HealthDataType.dietaryWater:
         return 'dietaryWater';
 


### PR DESCRIPTION
## Summary

Mirrors [`the-momentum/open_wearables_ios_sdk#14`](https://github.com/the-momentum/open_wearables_ios_sdk/pull/14) on the Flutter side. Adds Dart enum entries (and the matching `HealthDataTypeId.id` strings) for the eight dietary nutrients that iOS nutrition apps commonly log but which this SDK currently cannot request or forward: saturated / monounsaturated / polyunsaturated fat, fiber, sugar, sodium, cholesterol, caffeine.

### What lands

`lib/health_data_type.dart`:

| Layer | Change |
| --- | --- |
| `HealthDataType` enum | 8 new cases under the existing `// Nutrition` block |
| `HealthDataTypeId.id` extension | 8 new `case` arms returning verbatim lowerCamelCase strings that line up 1:1 with the native-SDK cases (required by the doc-comment: *\"must match iOS `mapTypes` string identifiers\"*) |

No changes to the plugin bridge or consumer API surface. Consumers that already pass `HealthDataType.values` to `requestAuthorization` (as the example app does) automatically pick these up once the native SDK patch ships.

### Companion PRs

- Native iOS SDK enum + unit mapping: [the-momentum/open_wearables_ios_sdk#14](https://github.com/the-momentum/open_wearables_ios_sdk/pull/14)
- Backend `SDKMetricType` + `SeriesType` + mappings: [the-momentum/open-wearables#961](https://github.com/the-momentum/open-wearables/pull/961)

This PR on its own is a no-op at runtime until the native SDK patch lands — the Dart-side identifier strings would be forwarded through the method channel, but the native `mapTypes` switch would return `nil` for them. Merging is safe in either order though, since `toHKSampleType()` is `nil`-returning rather than error-raising.

### Testing

- `dart analyze lib/health_data_type.dart` — no issues

## Test plan

- [ ] `dart analyze` clean on the whole package
- [ ] Example app requests authorization for one of the new types and iOS permission sheet lists it (requires native SDK #14 merged)
- [ ] Log a food in FoodNoms / Apple Health, trigger an SDK sync, and confirm backend receives the matching `HKQuantityTypeIdentifierDietary*` payload