### PR TITLE
feat(mtls,sync): Backwards compatible mtls support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,6 +16,7 @@ buildscript {
 
 rootProject.allprojects {
     repositories {
+        mavenLocal()
         maven {
             url = uri("https://jitpack.io")
         }
@@ -49,7 +50,7 @@ android {
     }
 
     dependencies {
-        implementation("com.github.the-momentum.open_wearables_android_sdk:sdk:v0.10.0")
+        implementation("com.openwearables.health:sdk:0.11.0")
 
         // Testing
         testImplementation("org.jetbrains.kotlin:kotlin-test")

--- a/android/src/main/kotlin/com/openwearables/health/sdk/OpenWearablesHealthSdkPlugin.kt
+++ b/android/src/main/kotlin/com/openwearables/health/sdk/OpenWearablesHealthSdkPlugin.kt
@@ -178,7 +178,41 @@ class OpenWearablesHealthSdkPlugin : FlutterPlugin, MethodCallHandler, ActivityA
             "getAvailableProviders" -> result.success(s.getAvailableProviders())
             "setSyncNotification" -> handleSetSyncNotification(s, call, result)
             "setLogLevel" -> handleSetLogLevel(s, call, result)
+            "pickClientCertificate" -> handlePickClientCertificate(s, call, result)
+            "getClientCertificateAlias" -> result.success(s.getClientCertificateAlias())
+            "clearClientCertificate" -> { s.clearClientCertificate(); result.success(null) }
+            "redeemInvitationCode" -> handleRedeemInvitationCode(s, call, result)
             else -> result.notImplemented()
+        }
+    }
+
+    private fun handlePickClientCertificate(sdk: OpenWearablesHealthSDK, call: MethodCall, result: Result) {
+        val hostHint = call.argument<String>("hostHint")
+        var replied = false
+        sdk.pickClientCertificate(hostHint) { alias ->
+            // KeyChain may invoke the callback on a non-main thread; marshal back.
+            android.os.Handler(android.os.Looper.getMainLooper()).post {
+                if (!replied) {
+                    replied = true
+                    result.success(alias)
+                }
+            }
+        }
+    }
+
+    private fun handleRedeemInvitationCode(sdk: OpenWearablesHealthSDK, call: MethodCall, result: Result) {
+        val host = call.argument<String>("host")
+        val code = call.argument<String>("code")
+        if (host.isNullOrEmpty() || code.isNullOrEmpty()) {
+            result.error("bad_args", "host and code are required", null); return
+        }
+        scope.launch {
+            try {
+                val response = sdk.redeemInvitationCode(host, code)
+                result.success(response)
+            } catch (e: Exception) {
+                result.error("redeem_failed", e.message, null)
+            }
         }
     }
 

--- a/example/android/app/src/main/res/values/strings.xml
+++ b/example/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!--
+      mTLS PKCS#12 keystore password. The native SDK reads this on initialize
+      to install a client cert at the OkHttp layer. Replace REPLACE_ME with
+      the password used when generating openwearables_client.p12.
+      Do NOT commit a real password to source control.
+    -->
+    <!--
+      Optional fallback: only used if you bundle an openwearables_client.p12
+      directly into the APK assets. The recommended path is to install the
+      cert via Android Settings → Security → Install certificate from
+      storage, then call OpenWearablesHealthSdk.pickClientCertificate() —
+      no APK rebuild needed for cert rotation. Leave as REPLACE_ME (or
+      remove this string entirely) to disable the assets fallback.
+    -->
+    <string name="openwearables_mtls_p12_password" translatable="false">REPLACE_ME</string>
+</resources>

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+kotlin.incremental=false

--- a/example/android/settings.gradle.kts
+++ b/example/android/settings.gradle.kts
@@ -25,3 +25,12 @@ plugins {
 }
 
 include(":app")
+
+// Use the local, mTLS-patched copy of the Android SDK instead of the
+// upstream JitPack artifact declared in ../android/build.gradle.
+includeBuild("../../../open_wearables_android_sdk") {
+    dependencySubstitution {
+        substitute(module("com.github.the-momentum.open_wearables_android_sdk:sdk"))
+            .using(project(":sdk"))
+    }
+}

--- a/example/android/settings.gradle.kts
+++ b/example/android/settings.gradle.kts
@@ -26,11 +26,15 @@ plugins {
 
 include(":app")
 
-// Use the local, mTLS-patched copy of the Android SDK instead of the
-// upstream JitPack artifact declared in ../android/build.gradle.
-includeBuild("../../../open_wearables_android_sdk") {
-    dependencySubstitution {
-        substitute(module("com.github.the-momentum.open_wearables_android_sdk:sdk"))
-            .using(project(":sdk"))
+// Use the local, mTLS-patched copy of the Android SDK when the sibling repo
+// is checked out. Falls back to the JitPack artifact on CI or machines that
+// don't have open_wearables_android_sdk checked out next to this repo.
+val localAndroidSdk = file("../../../open_wearables_android_sdk")
+if (localAndroidSdk.exists()) {
+    includeBuild(localAndroidSdk) {
+        dependencySubstitution {
+            substitute(module("com.github.the-momentum.open_wearables_android_sdk:sdk"))
+                .using(project(":sdk"))
+        }
     }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -690,7 +690,7 @@ class _HomePageState extends State<HomePage> {
                           ? 'No client certificate selected'
                           : 'Cert: $_clientCertAlias',
                       style: const TextStyle(
-                          color: OWColors.text, fontSize: 15),
+                          color: OWColors.textSecondary, fontSize: 15),
                       overflow: TextOverflow.ellipsis,
                     ),
                   ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -345,9 +345,9 @@ class _HomePageState extends State<HomePage> {
         code: invitationCode,
       );
 
-      final statusCode = response['statusCode'] as int? ?? 0;
-      final body = response['body'] as String? ?? '';
-      final data = (response['data'] as Map?)?.cast<String, dynamic>() ?? const {};
+      final statusCode = response.statusCode;
+      final body = response.body;
+      final data = response.data;
 
       if (statusCode != 200) {
         _setStatus('Redeem failed ($statusCode): $body');

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,9 +1,7 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
 import 'package:open_wearables_health_sdk/health_data_type.dart';
 import 'package:open_wearables_health_sdk/open_wearables_health_sdk.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
@@ -131,11 +129,48 @@ class _HomePageState extends State<HomePage> {
   List<AvailableProvider> _availableProviders = [];
   String? _selectedProviderId;
 
+  // Selected mTLS client cert alias (KeyChain). Null if none picked yet, or
+  // on iOS where this is unsupported.
+  String? _clientCertAlias;
+
   @override
   void initState() {
     super.initState();
     _subscribeToNativeLogs();
     _autoConfigureOnStartup();
+    _loadClientCertAlias();
+  }
+
+  Future<void> _loadClientCertAlias() async {
+    if (!Platform.isAndroid) return;
+    try {
+      final alias = await OpenWearablesHealthSdk.getClientCertificateAlias();
+      if (mounted) setState(() => _clientCertAlias = alias);
+    } catch (_) {
+      // Method channel not yet attached or unsupported — leave null.
+    }
+  }
+
+  Future<void> _pickClientCert() async {
+    if (!Platform.isAndroid) return;
+    final hostHint = _hostController.text.trim().isEmpty
+        ? null
+        : Uri.tryParse(_hostController.text.trim())?.host;
+    final alias =
+        await OpenWearablesHealthSdk.pickClientCertificate(hostHint: hostHint);
+    if (!mounted) return;
+    setState(() => _clientCertAlias = alias);
+    _setStatus(alias == null
+        ? 'No certificate selected'
+        : 'Using certificate: $alias');
+  }
+
+  Future<void> _clearClientCert() async {
+    if (!Platform.isAndroid) return;
+    await OpenWearablesHealthSdk.clearClientCertificate();
+    if (!mounted) return;
+    setState(() => _clientCertAlias = null);
+    _setStatus('Cleared client certificate');
   }
 
   void _subscribeToNativeLogs() {
@@ -302,33 +337,34 @@ class _HomePageState extends State<HomePage> {
     try {
       _setStatus('Redeeming invitation code...');
 
-      // Build redeem URL: {host}/api/v1/invitation-code/redeem
-      final h = host.endsWith('/') ? host.substring(0, host.length - 1) : host;
-      final redeemUrl = Uri.parse('$h/api/v1/invitation-code/redeem');
-
-      final response = await http.post(
-        redeemUrl,
-        headers: {'Content-Type': 'application/json'},
-        body: jsonEncode({'code': invitationCode}),
+      // Goes through the native SDK's OkHttp client so the configured client
+      // certificate (KeyChain alias or assets fallback) is presented during
+      // the TLS handshake. This is required when the backend is behind mTLS.
+      final response = await OpenWearablesHealthSdk.redeemInvitationCode(
+        host: host,
+        code: invitationCode,
       );
 
-      if (response.statusCode != 200) {
-        _setStatus('Redeem failed (${response.statusCode}): ${response.body}');
+      final statusCode = response['statusCode'] as int? ?? 0;
+      final body = response['body'] as String? ?? '';
+      final data = (response['data'] as Map?)?.cast<String, dynamic>() ?? const {};
+
+      if (statusCode != 200) {
+        _setStatus('Redeem failed ($statusCode): $body');
         Sentry.captureEvent(
           SentryEvent(
             message: SentryMessage('Invitation code redeem failed'),
             level: SentryLevel.warning,
-            tags: {'statusCode': '${response.statusCode}', 'host': host},
+            tags: {'statusCode': '$statusCode', 'host': host},
             contexts: Contexts()
               ..['response_details'] = {
-                'body': response.body.length > 500 ? response.body.substring(0, 500) : response.body,
+                'body': body.length > 500 ? body.substring(0, 500) : body,
               },
           ),
         );
         return;
       }
 
-      final data = jsonDecode(response.body) as Map<String, dynamic>;
       final accessToken = data['access_token'] as String?;
       final refreshToken = data['refresh_token'] as String?;
       final userId = data['user_id'] as String?;
@@ -639,6 +675,39 @@ class _HomePageState extends State<HomePage> {
             placeholder: 'Invitation Code',
             icon: CupertinoIcons.ticket,
           ),
+          if (Platform.isAndroid) _buildDivider(),
+          if (Platform.isAndroid)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              child: Row(
+                children: [
+                  const Icon(CupertinoIcons.lock_shield,
+                      color: OWColors.textMuted, size: 20),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      _clientCertAlias == null
+                          ? 'No client certificate selected'
+                          : 'Cert: $_clientCertAlias',
+                      style: const TextStyle(
+                          color: OWColors.text, fontSize: 15),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: _isLoading ? null : _pickClientCert,
+                    child: Text(
+                      _clientCertAlias == null ? 'Select' : 'Change',
+                    ),
+                  ),
+                  if (_clientCertAlias != null)
+                    TextButton(
+                      onPressed: _isLoading ? null : _clearClientCert,
+                      child: const Text('Clear'),
+                    ),
+                ],
+              ),
+            ),
           Padding(
             padding: const EdgeInsets.all(20),
             child: SizedBox(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -195,10 +195,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -351,10 +351,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:

--- a/lib/open_wearables_health_sdk.dart
+++ b/lib/open_wearables_health_sdk.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:open_wearables_health_sdk/health_data_type.dart';
@@ -11,6 +12,7 @@ import 'package:open_wearables_health_sdk/src/user.dart';
 
 import 'open_wearables_health_sdk_method_channel.dart';
 import 'open_wearables_health_sdk_platform_interface.dart';
+import 'src/redeem_result.dart';
 
 export 'package:open_wearables_health_sdk/src/config.dart';
 export 'package:open_wearables_health_sdk/src/exceptions.dart';
@@ -19,6 +21,7 @@ export 'package:open_wearables_health_sdk/src/provider.dart';
 export 'package:open_wearables_health_sdk/src/status.dart';
 export 'package:open_wearables_health_sdk/src/user.dart';
 export 'open_wearables_health_sdk_method_channel.dart';
+export 'src/redeem_result.dart';
 
 /// Ensure MethodChannel is the default implementation.
 /// This runs at library load time before any static methods can be called.
@@ -501,18 +504,23 @@ class OpenWearablesHealthSdk {
   /// Prompts the user to pick a client certificate from the Android system
   /// KeyChain. The selected alias is persisted; subsequent app launches
   /// auto-install it on the SDK's HTTP client. Returns the chosen alias, or
-  /// null if cancelled. iOS / no-Activity cases return null.
+  /// null if cancelled. Returns null immediately on non-Android platforms.
   static Future<String?> pickClientCertificate({String? hostHint}) {
+    if (!Platform.isAndroid) return Future.value(null);
     return _platform.pickClientCertificate(hostHint: hostHint);
   }
 
   /// Returns the alias currently selected for mTLS, or null if none.
+  /// Returns null immediately on non-Android platforms.
   static Future<String?> getClientCertificateAlias() {
+    if (!Platform.isAndroid) return Future.value(null);
     return _platform.getClientCertificateAlias();
   }
 
   /// Forgets the currently selected client certificate alias.
+  /// No-op on non-Android platforms.
   static Future<void> clearClientCertificate() {
+    if (!Platform.isAndroid) return Future.value();
     return _platform.clearClientCertificate();
   }
 
@@ -520,11 +528,15 @@ class OpenWearablesHealthSdk {
   /// configured client certificate (if any) is presented during the TLS
   /// handshake. Use this instead of a Dart `http.post` when the backend is
   /// behind mTLS — the cert lives in Android KeyChain and isn't accessible
-  /// from Dart's `dart:io` HttpClient.
-  static Future<Map<String, dynamic>> redeemInvitationCode({
+  /// from Dart's `dart:io` HttpClient. Throws [UnsupportedError] on
+  /// non-Android platforms.
+  static Future<RedeemResult> redeemInvitationCode({
     required String host,
     required String code,
   }) {
+    if (!Platform.isAndroid) {
+      throw UnsupportedError('redeemInvitationCode is only supported on Android');
+    }
     return _platform.redeemInvitationCode(host: host, code: code);
   }
 

--- a/lib/open_wearables_health_sdk.dart
+++ b/lib/open_wearables_health_sdk.dart
@@ -496,6 +496,38 @@ class OpenWearablesHealthSdk {
     }
   }
 
+  // MARK: - mTLS client certificate (Android KeyChain)
+
+  /// Prompts the user to pick a client certificate from the Android system
+  /// KeyChain. The selected alias is persisted; subsequent app launches
+  /// auto-install it on the SDK's HTTP client. Returns the chosen alias, or
+  /// null if cancelled. iOS / no-Activity cases return null.
+  static Future<String?> pickClientCertificate({String? hostHint}) {
+    return _platform.pickClientCertificate(hostHint: hostHint);
+  }
+
+  /// Returns the alias currently selected for mTLS, or null if none.
+  static Future<String?> getClientCertificateAlias() {
+    return _platform.getClientCertificateAlias();
+  }
+
+  /// Forgets the currently selected client certificate alias.
+  static Future<void> clearClientCertificate() {
+    return _platform.clearClientCertificate();
+  }
+
+  /// Redeems an invitation code through the SDK's native HTTP client, so the
+  /// configured client certificate (if any) is presented during the TLS
+  /// handshake. Use this instead of a Dart `http.post` when the backend is
+  /// behind mTLS — the cert lives in Android KeyChain and isn't accessible
+  /// from Dart's `dart:io` HttpClient.
+  static Future<Map<String, dynamic>> redeemInvitationCode({
+    required String host,
+    required String code,
+  }) {
+    return _platform.redeemInvitationCode(host: host, code: code);
+  }
+
   // MARK: - Helpers
 
   static void _ensureSignedIn() {

--- a/lib/open_wearables_health_sdk_method_channel.dart
+++ b/lib/open_wearables_health_sdk_method_channel.dart
@@ -180,4 +180,33 @@ class MethodChannelOpenWearablesHealthSdk extends OpenWearablesHealthSdkPlatform
   Future<void> setLogLevel({required String level}) async {
     await _channel.invokeMethod<void>('setLogLevel', {'level': level});
   }
+
+  @override
+  Future<String?> pickClientCertificate({String? hostHint}) async {
+    return _channel.invokeMethod<String?>('pickClientCertificate', {
+      if (hostHint != null) 'hostHint': hostHint,
+    });
+  }
+
+  @override
+  Future<String?> getClientCertificateAlias() async {
+    return _channel.invokeMethod<String?>('getClientCertificateAlias');
+  }
+
+  @override
+  Future<void> clearClientCertificate() async {
+    await _channel.invokeMethod<void>('clearClientCertificate');
+  }
+
+  @override
+  Future<Map<String, dynamic>> redeemInvitationCode({
+    required String host,
+    required String code,
+  }) async {
+    final result = await _channel.invokeMethod<Map<Object?, Object?>>(
+      'redeemInvitationCode',
+      {'host': host, 'code': code},
+    );
+    return (result ?? {}).map((k, v) => MapEntry(k.toString(), v));
+  }
 }

--- a/lib/open_wearables_health_sdk_method_channel.dart
+++ b/lib/open_wearables_health_sdk_method_channel.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 
 import 'open_wearables_health_sdk_platform_interface.dart';
 import 'src/exceptions.dart';
+import 'src/redeem_result.dart';
 
 /// MethodChannel-based implementation of the OpenWearablesHealthSdk platform interface.
 class MethodChannelOpenWearablesHealthSdk extends OpenWearablesHealthSdkPlatform {
@@ -199,7 +200,7 @@ class MethodChannelOpenWearablesHealthSdk extends OpenWearablesHealthSdkPlatform
   }
 
   @override
-  Future<Map<String, dynamic>> redeemInvitationCode({
+  Future<RedeemResult> redeemInvitationCode({
     required String host,
     required String code,
   }) async {
@@ -207,6 +208,6 @@ class MethodChannelOpenWearablesHealthSdk extends OpenWearablesHealthSdkPlatform
       'redeemInvitationCode',
       {'host': host, 'code': code},
     );
-    return (result ?? {}).map((k, v) => MapEntry(k.toString(), v));
+    return RedeemResult.fromMap(result ?? {});
   }
 }

--- a/lib/open_wearables_health_sdk_platform_interface.dart
+++ b/lib/open_wearables_health_sdk_platform_interface.dart
@@ -165,6 +165,35 @@ abstract class OpenWearablesHealthSdkPlatform extends PlatformInterface {
   Future<void> setLogLevel({required String level}) {
     throw UnimplementedError('setLogLevel() has not been implemented.');
   }
+
+  // MARK: - mTLS client certificate (Android KeyChain)
+
+  /// Prompts the user to pick a client certificate from the Android system
+  /// KeyChain. Returns the chosen alias, or null if cancelled / unsupported.
+  Future<String?> pickClientCertificate({String? hostHint}) {
+    throw UnimplementedError('pickClientCertificate() has not been implemented.');
+  }
+
+  /// Returns the alias currently selected for mTLS, or null if none.
+  Future<String?> getClientCertificateAlias() {
+    throw UnimplementedError('getClientCertificateAlias() has not been implemented.');
+  }
+
+  /// Forgets the currently selected client certificate alias.
+  Future<void> clearClientCertificate() {
+    throw UnimplementedError('clearClientCertificate() has not been implemented.');
+  }
+
+  /// Redeems an invitation code against `{host}/api/v1/invitation-code/redeem`
+  /// using the SDK's HTTP client (so the configured client certificate, if
+  /// any, is presented). Returns a map with `statusCode` (int), `body`
+  /// (String), and `data` (Map<String, dynamic>).
+  Future<Map<String, dynamic>> redeemInvitationCode({
+    required String host,
+    required String code,
+  }) {
+    throw UnimplementedError('redeemInvitationCode() has not been implemented.');
+  }
 }
 
 /// NO-OP placeholder.

--- a/lib/open_wearables_health_sdk_platform_interface.dart
+++ b/lib/open_wearables_health_sdk_platform_interface.dart
@@ -1,5 +1,7 @@
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
+import 'src/redeem_result.dart';
+
 /// Defines the interface for the OpenWearablesHealthSdk plugin.
 abstract class OpenWearablesHealthSdkPlatform extends PlatformInterface {
   OpenWearablesHealthSdkPlatform() : super(token: _token);
@@ -186,9 +188,8 @@ abstract class OpenWearablesHealthSdkPlatform extends PlatformInterface {
 
   /// Redeems an invitation code against `{host}/api/v1/invitation-code/redeem`
   /// using the SDK's HTTP client (so the configured client certificate, if
-  /// any, is presented). Returns a map with `statusCode` (int), `body`
-  /// (String), and `data` (Map<String, dynamic>).
-  Future<Map<String, dynamic>> redeemInvitationCode({
+  /// any, is presented).
+  Future<RedeemResult> redeemInvitationCode({
     required String host,
     required String code,
   }) {

--- a/lib/src/redeem_result.dart
+++ b/lib/src/redeem_result.dart
@@ -1,0 +1,21 @@
+/// Typed result returned by [OpenWearablesHealthSdk.redeemInvitationCode].
+class RedeemResult {
+  final int statusCode;
+  final String body;
+  final Map<String, dynamic> data;
+
+  const RedeemResult({
+    required this.statusCode,
+    required this.body,
+    required this.data,
+  });
+
+  factory RedeemResult.fromMap(Map<Object?, Object?> map) {
+    final rawData = map['data'];
+    return RedeemResult(
+      statusCode: map['statusCode'] as int? ?? 0,
+      body: map['body'] as String? ?? '',
+      data: rawData is Map ? rawData.cast<String, dynamic>() : const {},
+    );
+  }
+}


### PR DESCRIPTION
This pull request adds support for mTLS client certificate management on Android, enabling the app to select, use, and clear a client certificate from the Android KeyChain for secure backend communication. It also introduces a new method for redeeming invitation codes through the SDK's native HTTP client, ensuring the selected certificate is used during mTLS handshakes. The Dart API, platform interface, and Android plugin are all updated to support these features, and the example app is updated to demonstrate the new workflow.

**mTLS Client Certificate Management (Android):**
- Added methods to pick, get, and clear a client certificate alias from the Android KeyChain in both the Dart API (`OpenWearablesHealthSdk`) and the Android plugin (`OpenWearablesHealthSdkPlugin`). This enables secure mTLS communication using a user-selected certificate. [[1]](diffhunk://#diff-6023834f25a99b47a75f79fee24eff1a9ea8c1a2b9cf39ad8711586edc945428R502-R542) [[2]](diffhunk://#diff-fa2782ffe18b4b6ea54cada608306a064bede283ff40fbe7664e6a0cb956da94R184-R212) [[3]](diffhunk://#diff-48dc928411212aaaf3711becb0970ac2ca00e3f76e786a34fc4cadb53ea570fdR170-R197) [[4]](diffhunk://#diff-7e3bd954091b098976bd3d7f1f66b9c9da7d47b138c336a63fb8c17e2d6378d3R181-R218)
- Updated the example app UI to allow users to select, view, and clear the client certificate, and to display the currently selected alias. [[1]](diffhunk://#diff-72fd825ad17ce7800a2078e06f0dff1e12836ee59760465e78d9a5d222cebd15R132-R173) [[2]](diffhunk://#diff-72fd825ad17ce7800a2078e06f0dff1e12836ee59760465e78d9a5d222cebd15R678-R710)

**Invitation Code Redemption (mTLS-aware):**
- Added a new Dart API method (`redeemInvitationCode`) and corresponding platform interface and Android implementation to redeem invitation codes via the SDK's HTTP client, ensuring the configured client certificate is used for mTLS. Introduced a typed `RedeemResult` for structured responses. [[1]](diffhunk://#diff-6023834f25a99b47a75f79fee24eff1a9ea8c1a2b9cf39ad8711586edc945428R502-R542) [[2]](diffhunk://#diff-fa2782ffe18b4b6ea54cada608306a064bede283ff40fbe7664e6a0cb956da94R184-R212) [[3]](diffhunk://#diff-48dc928411212aaaf3711becb0970ac2ca00e3f76e786a34fc4cadb53ea570fdR170-R197) [[4]](diffhunk://#diff-70160563afd364e9700dc737c93bf52f67f0cfc7ebfc0cf502e6b29094bd2db3R1-R21) [[5]](diffhunk://#diff-7e3bd954091b098976bd3d7f1f66b9c9da7d47b138c336a63fb8c17e2d6378d3R181-R218)
- Refactored the example app to use the new SDK method for invitation code redemption instead of direct HTTP requests, allowing it to work with mTLS-protected backends.

**Build and Configuration Improvements:**
- Updated the example app's Gradle settings to support using a local, patched version of the Android SDK for development and CI flexibility.
- Added a placeholder for the mTLS PKCS#12 keystore password in the example app's resources, with guidance for secure usage.

**Code Cleanup:**
- Removed unused imports from the example app.
- Added missing imports in the main Dart API file for new features. [[1]](diffhunk://#diff-6023834f25a99b47a75f79fee24eff1a9ea8c1a2b9cf39ad8711586edc945428R2) [[2]](diffhunk://#diff-6023834f25a99b47a75f79fee24eff1a9ea8c1a2b9cf39ad8711586edc945428R15) [[3]](diffhunk://#diff-6023834f25a99b47a75f79fee24eff1a9ea8c1a2b9cf39ad8711586edc945428R24)

**New Types:**
- Introduced the `RedeemResult` class to encapsulate HTTP status, body, and parsed data for invitation code redemption responses.